### PR TITLE
Dane remove extreme turbidities

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ title: POST
 <script type="text/javascript">
 	$(document).ready(function(){
 		$('ul.tabs').tabs({
-			'swipeable': true; // can only work if 
+			'swipeable': true // can only work if 
 		});
 	});
 </script>

--- a/js/db.js
+++ b/js/db.js
@@ -97,6 +97,7 @@ function updatePlantData(onSuccess){
 		}
 		// Save plant data into the local storage
 		var plantDataDictArray = makeDictionary(json.rows, json.columns);
+		plantDataDictArray = filterExtremes(plantDataDictArray);
 		number_of_returned_data_points = json.rows.length;
 		insertManyPlantData(plantDataDictArray);
 		// Call the callback and use the retrieve function to get plantdata
@@ -146,4 +147,65 @@ function getAllPlantsDict(){
 		"snic":"San Nicolas", 
 		"tam":"Tamara"
 	}
+};
+
+function filterExtremes(plantDataDictArray){
+//Raw
+var sum = 0;
+var sumsq = 0;
+for (var i=0; i<plantDataDictArray.length; ++i){
+	if (!isNaN(plantDataDictArray[i].rawWaterTurbidity)) {
+		sum += Number(plantDataDictArray[i].rawWaterTurbidity);
+		sumsq+= Number(plantDataDictArray[i].rawWaterTurbidity)*Number(plantDataDictArray[i].rawWaterTurbidity);
+	}
+}
+var l = plantDataDictArray.length;
+var mean = sum/l; 
+var variance = sumsq / l - mean*mean;
+var sd = Math.sqrt(variance);
+for(var i=plantDataDictArray.length;i--;) {
+	if(Number(plantDataDictArray[i].rawWaterTurbidity) < mean - 3*sd || Number(plantDataDictArray[i].rawWaterTurbidity) > mean + 3*sd){
+		plantDataDictArray.splice(i,1);
+	}
+}
+
+//Settled
+var sum2 = 0;
+var sumsq2 = 0;
+for (var i=0; i<plantDataDictArray.length; ++i){
+	if (!isNaN(plantDataDictArray[i].settledWaterTurbidity)) {
+		sum2 += Number(plantDataDictArray[i].settledWaterTurbidity);
+		sumsq2+= Number(plantDataDictArray[i].settledWaterTurbidity)*Number(plantDataDictArray[i].settledWaterTurbidity);
+	}
+}
+var l2 = plantDataDictArray.length;
+var mean2 = sum2/l2; 
+var variance2 = sumsq2 / l2 - mean2*mean2;
+var sd2 = Math.sqrt(variance2);
+for(var i=plantDataDictArray.length;i--;) {
+	if(Number(plantDataDictArray[i].settledWaterTurbidity) < mean2 - 3*sd2 || Number(plantDataDictArray[i].settledWaterTurbidity) > mean2 + 3*sd2){
+		plantDataDictArray.splice(i,1);
+	}
+}
+
+//Filtered
+var sum3 = 0;
+var sumsq3 = 0;
+for (var i=0; i<plantDataDictArray.length; ++i){
+	if (!isNaN(plantDataDictArray[i].filteredWaterTurbidity)) {
+		sum3 += Number(plantDataDictArray[i].filteredWaterTurbidity);
+		sumsq3+= Number(plantDataDictArray[i].filteredWaterTurbidity)*Number(plantDataDictArray[i].filteredWaterTurbidity);
+	}
+}
+var l3 = plantDataDictArray.length;
+var mean3 = sum3/l3; 
+var variance3 = sumsq3 / l3 - mean3*mean3;
+var sd3 = Math.sqrt(variance3);
+for(var i=plantDataDictArray.length;i--;) {
+	if(Number(plantDataDictArray[i].filteredWaterTurbidity) < mean3 - 3*sd3 || Number(plantDataDictArray[i].filteredWaterTurbidity) > mean3 + 3*sd3){
+		plantDataDictArray.splice(i,1);
+	}
+}
+
+return plantDataDictArray;
 };

--- a/js/db.js
+++ b/js/db.js
@@ -84,7 +84,7 @@ function makeDictionary(rowArray, columnArray) {
 // TODO: onFailure. 
 function updatePlantData(onSuccess){
 	var plantName = getPlantName();
-	var sql_query = "SELECT * FROM " + table_id + " WHERE plant=" + "'" + plantName + "'" + " ORDER BY timeFinished DESC LIMIT " + number_of_requested_data_points;
+	var sql_query = "SELECT * FROM " + table_id + " WHERE plant=" + "'" + plantName + "'" + " AND rawWaterTurbidity > 0 ORDER BY timeFinished DESC LIMIT " + number_of_requested_data_points;
 	sql_query_url = encode_fusion_table_sql(sql_query);
 	console.log(sql_query_url);
 	// Get the JSON corresponding to the encoded sql string
@@ -150,62 +150,25 @@ function getAllPlantsDict(){
 };
 
 function filterExtremes(plantDataDictArray){
-//Raw
-var sum = 0;
-var sumsq = 0;
-for (var i=0; i<plantDataDictArray.length; ++i){
-	if (!isNaN(plantDataDictArray[i].rawWaterTurbidity)) {
-		sum += Number(plantDataDictArray[i].rawWaterTurbidity);
-		sumsq+= Number(plantDataDictArray[i].rawWaterTurbidity)*Number(plantDataDictArray[i].rawWaterTurbidity);
+var params = ['rawWaterTurbidity', 'settledWaterTurbidity', 'filteredWaterTurbidity'];
+params.forEach(function(param) {
+	var sum = 0;
+	var sumsq = 0;
+	for (var i = 0; i<plantDataDictArray.length; ++i){
+		if (!isNaN(plantDataDictArray[i][param])) {
+			sum += Number(plantDataDictArray[i][param]);
+			sumsq += Number(plantDataDictArray[i][param])*Number(plantDataDictArray[i][param]);
+		}
 	}
-}
-var l = plantDataDictArray.length;
-var mean = sum/l; 
-var variance = sumsq / l - mean*mean;
-var sd = Math.sqrt(variance);
-for(var i=plantDataDictArray.length;i--;) {
-	if(Number(plantDataDictArray[i].rawWaterTurbidity) < mean - 3*sd || Number(plantDataDictArray[i].rawWaterTurbidity) > mean + 3*sd){
-		plantDataDictArray.splice(i,1);
+	var l = plantDataDictArray.length;
+	var mean = sum/l; 		
+	var variance = sumsq / l - mean*mean;
+	var sd = Math.sqrt(variance);
+	for(var i=plantDataDictArray.length;i--;) {
+		if(Number(plantDataDictArray[i][param]) < mean - 3*sd || Number(plantDataDictArray[i][param]) > mean + 3*sd){
+			plantDataDictArray.splice(i,1);
+		}
 	}
-}
-
-//Settled
-var sum2 = 0;
-var sumsq2 = 0;
-for (var i=0; i<plantDataDictArray.length; ++i){
-	if (!isNaN(plantDataDictArray[i].settledWaterTurbidity)) {
-		sum2 += Number(plantDataDictArray[i].settledWaterTurbidity);
-		sumsq2+= Number(plantDataDictArray[i].settledWaterTurbidity)*Number(plantDataDictArray[i].settledWaterTurbidity);
-	}
-}
-var l2 = plantDataDictArray.length;
-var mean2 = sum2/l2; 
-var variance2 = sumsq2 / l2 - mean2*mean2;
-var sd2 = Math.sqrt(variance2);
-for(var i=plantDataDictArray.length;i--;) {
-	if(Number(plantDataDictArray[i].settledWaterTurbidity) < mean2 - 3*sd2 || Number(plantDataDictArray[i].settledWaterTurbidity) > mean2 + 3*sd2){
-		plantDataDictArray.splice(i,1);
-	}
-}
-
-//Filtered
-var sum3 = 0;
-var sumsq3 = 0;
-for (var i=0; i<plantDataDictArray.length; ++i){
-	if (!isNaN(plantDataDictArray[i].filteredWaterTurbidity)) {
-		sum3 += Number(plantDataDictArray[i].filteredWaterTurbidity);
-		sumsq3+= Number(plantDataDictArray[i].filteredWaterTurbidity)*Number(plantDataDictArray[i].filteredWaterTurbidity);
-	}
-}
-var l3 = plantDataDictArray.length;
-var mean3 = sum3/l3; 
-var variance3 = sumsq3 / l3 - mean3*mean3;
-var sd3 = Math.sqrt(variance3);
-for(var i=plantDataDictArray.length;i--;) {
-	if(Number(plantDataDictArray[i].filteredWaterTurbidity) < mean3 - 3*sd3 || Number(plantDataDictArray[i].filteredWaterTurbidity) > mean3 + 3*sd3){
-		plantDataDictArray.splice(i,1);
-	}
-}
-
+})
 return plantDataDictArray;
 };

--- a/js/db.js
+++ b/js/db.js
@@ -12,8 +12,8 @@ var table_id = "1Sk13vckXZIuOaokQ6tbOkHjRAthBFF7FkgsGaSjD"
 var api_key = "&key=AIzaSyAAWkBly-1cwH3rbyLIhoZtJAY3RUHrViM";
 var number_of_requested_data_points = 100;
 
-//controls the filter function. options are {"one_order_magnitude","two_order_magnitude","three_std","six_std","ten_std"}
-var filterFunc = "three_std"
+//controls the filter function. options are {"none",one_order_magnitude","two_order_magnitude","three_std","six_std","ten_std"}
+var filterFunc = "six_std"
 
 
 // We only know how many data points there are for a specific plant request when we actually get the response
@@ -155,6 +155,7 @@ function getAllPlantsDict(){
 // passed as a filter guard in filterExtremes. Control this by changing the global [filterFunc] variable
 function checkSanity(datum){
 	var guards = {
+		"none": true,
 		"one_order_magnitude":datum[this.param] <= this.mean*10,
 		"two_order_magnitude":datum[this.param] <= this.mean*100,
 		"three_std":(datum[this.param] >= this.mean - 3.0*this.sd) && (datum[this.param] <= this.mean + 3.0*this.sd),
@@ -190,6 +191,5 @@ function filterExtremes(plantDataDictArray){
 		var sd = Math.sqrt(variance);
 		plantDataDictArray=plantDataDictArray.filter(checkSanity,{"param":param,"mean":mean,"sd":sd});
 	})
-
 	return plantDataDictArray;
 };

--- a/js/db.js
+++ b/js/db.js
@@ -98,7 +98,7 @@ function updatePlantData(onSuccess){
 		// Save plant data into the local storage
 		var plantDataDictArray = makeDictionary(json.rows, json.columns);
 		plantDataDictArray = filterExtremes(plantDataDictArray);
-		number_of_returned_data_points = json.rows.length;
+		number_of_returned_data_points = plantDataDictArray.length;
 		insertManyPlantData(plantDataDictArray);
 		// Call the callback and use the retrieve function to get plantdata
 		onSuccess(retrieveAllPlantData(),plantName);


### PR DESCRIPTION
**New features:**
- Added a function that goes through plantDataDictArray and searches for raw, settled, and filtered turbidity values that are more than three standard deviations away from the mean. If an extreme value is found, the corresponding object is removed from the array. The function then returns the new plantDataDictArray which may or may not have removed values.

**Need Feedback On:**
- Is there a shorter way of making the filterExtremes function so that I can use 1 for loop for calculations and 1 for loop for removing extremes for all three turbidity types, or do I need to do it each time for each turbidity?

**Things it broke:**
-I don't think it broke anything

*Assuming a normal distribution of turbidity values, 99.7% of data values are within 3 standard deviations of the mean. Thus, this filter only removes data which is so far away from the mean that they are most likely values which were inputted incorrectly and would ruin visualizations, as opposed to data points which are actually that extreme in reality.
